### PR TITLE
Fix CI Playwright setup

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,6 +33,9 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
       
       - name: Make scripts executable
         run: |


### PR DESCRIPTION
## Summary
- install Playwright browsers during build workflow

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser binaries missing)*